### PR TITLE
Add a CLI toggle to enable pushing to Git remotes

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -656,7 +656,7 @@ def publish_to_github(collections_target_dir, spec):
             os.path.join(collection_dir, 'galaxy.yml'),
         )['repository']
         subprocess.check_call(
-            ('git', 'push', git_repo_url, 'HEAD:master'),
+            ('git', 'push', '--force', git_repo_url, 'HEAD:master'),
             cwd=collection_dir,
         )
 


### PR DESCRIPTION
The script won't push to Git remotes unless ``-P`` or ``--publish-to-github`` is specified in CLI args.

Resolves #26