### PR TITLE
Split long rewritten imports into sets of shorter ones

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -149,6 +149,16 @@ def write_fst_into_file(path, fst):
     write_text_into_file(path, fst.dumps().rstrip() + '\n')
 
 
+def render_fst(fst):
+    """Render FST node in color when in terminal."""
+    node_txt = str(fst)
+    if not sys.stdout.isatty() or redbaron.runned_from_ipython():
+        # It doesn't make sense to highlight non-tty output
+        # And also redbaron applies it by itself when under ipython
+        return node_txt
+    return redbaron.python_highlight(node_txt).decode()
+
+
 # ===== SPEC utils =====
 def load_spec_file(spec_file):
 
@@ -445,8 +455,20 @@ def respect_line_length(import_node, *, max_chars=79):
     ]
     for node, target in zip(replacement_import_nodes, import_targets):
         node.targets = target
+        node_bounding_box = (
+            node.bounding_box.bottom_right -
+            node.bounding_box.top_left
+        )
+        is_too_long = node_bounding_box.column > max_chars
+        if True or is_too_long:
+            logger.warning(
+                '%s-char long line `%s` is too long. '
+                'It exceeds the limit of %s chars.',
+                node_bounding_box.column,
+                render_fst(node),
+                max_chars,
+            )
     parent_node[replacement_position] = replacement_import_nodes
-    # TODO: validate new entries (replacement_import_nodes) too
 
 
 def read_module_txt_n_fst(path):

--- a/migrate.py
+++ b/migrate.py
@@ -144,6 +144,11 @@ def write_text_into_file(path, text):
         return f.write(text)
 
 
+def write_fst_into_file(path, fst):
+    """Dump fst into the given file path."""
+    write_text_into_file(path, fst.dumps().rstrip())
+
+
 # ===== SPEC utils =====
 def load_spec_file(spec_file):
 
@@ -752,7 +757,7 @@ def assemble_collections(spec, args, target_github_org):
                     except LookupError as err:
                         docs_dependencies = []
                         logger.info('%s in %s', err, src)
-                    plugin_data_new = mod_fst.dumps()
+                    plugin_data_new = mod_fst.dumps().rstrip()
 
                     if mod_src_text != plugin_data_new:
                         for dep_ns, dep_coll in docs_dependencies + import_dependencies:
@@ -781,7 +786,7 @@ def assemble_collections(spec, args, target_github_org):
             ):
                 _unit_test_module_src_text, unit_test_module_fst = read_module_txt_n_fst(file_path)
                 unit_deps += rewrite_imports(unit_test_module_fst, collection, spec, namespace, args)
-                write_text_into_file(file_path, unit_test_module_fst.dumps())
+                write_fst_into_file(dest, unit_test_module_fst)
 
             inject_gitignore_into_tests(collection_dir)
 
@@ -984,12 +989,11 @@ def rewrite_integration_tests(test_dirs, checkout_dir, collection_dir, namespace
                     except LookupError as err:
                         docs_dependencies = []
                         logger.info('%s in %s', err, full_path)
-                    plugin_data_new = mod_fst.dumps()
 
                     for dep_ns, dep_coll in docs_dependencies + import_dependencies:
                         integration_tests_add_to_deps((namespace, collection), (dep_ns, dep_coll))
 
-                    write_text_into_file(dest, plugin_data_new)
+                    write_fst_into_file(dest, mod_fst)
                 elif ext in ('.ps1',):
                     # FIXME
                     pass

--- a/migrate.py
+++ b/migrate.py
@@ -431,11 +431,11 @@ def respect_line_length(import_node, *, max_chars=79):
         import_node.index_on_parent + 1,
     )
     node_bounding_box = (
-        import_node.bounding_box.top_left -
-        import_node.bounding_box.bottom_right
+        import_node.bounding_box.bottom_right -
+        import_node.bounding_box.top_left
     )
 
-    is_too_long = node_bounding_box.column <= max_chars
+    is_too_long = node_bounding_box.column > max_chars
     if not is_too_long:
         return
 

--- a/migrate.py
+++ b/migrate.py
@@ -460,7 +460,7 @@ def respect_line_length(import_node, *, max_chars=79):
             node.bounding_box.top_left
         )
         is_too_long = node_bounding_box.column > max_chars
-        if True or is_too_long:
+        if is_too_long:
             logger.warning(
                 '%s-char long line `%s` is too long. '
                 'It exceeds the limit of %s chars.',

--- a/migrate.py
+++ b/migrate.py
@@ -146,7 +146,7 @@ def write_text_into_file(path, text):
 
 def write_fst_into_file(path, fst):
     """Dump fst into the given file path."""
-    write_text_into_file(path, fst.dumps().rstrip())
+    write_text_into_file(path, fst.dumps().rstrip() + '\n')
 
 
 # ===== SPEC utils =====
@@ -757,7 +757,7 @@ def assemble_collections(spec, args, target_github_org):
                     except LookupError as err:
                         docs_dependencies = []
                         logger.info('%s in %s', err, src)
-                    plugin_data_new = mod_fst.dumps().rstrip()
+                    plugin_data_new = mod_fst.dumps().rstrip() + '\n'
 
                     if mod_src_text != plugin_data_new:
                         for dep_ns, dep_coll in docs_dependencies + import_dependencies:


### PR DESCRIPTION
Only handles `from ... import ...` nodes.