### PR TITLE
Preserve unicode in DOCUMENTATION

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -411,7 +411,7 @@ def rewrite_plugin_documentation(mod_fst, collection, spec, namespace, args):
     # DOCUMENTATION = '''some string value'''
     # ```
     doc_val.value = doc_str_tmpl.format(
-        str_val=yaml.dump(docs_parsed),
+        str_val=yaml.dump(docs_parsed, allow_unicode=True, default_flow_style=False, sort_keys=False),
     )
 
     return deps


### PR DESCRIPTION
Mostly authors that have unicode chars in their names.