### PR TITLE
Use python-version arg in Actions

### DIFF
--- a/.github/workflows/collection-migration-tests.yml
+++ b/.github/workflows/collection-migration-tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
-        version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python-version }}
     - name: Uninstall previously installed Ansible via Apt
       run: sudo apt remove --yes ansible
     - name: Uninstall previously installed Ansible via Pip


### PR DESCRIPTION
Replacing the deprecated `version:` arg