### PR TITLE
get rid of notifications

### DIFF
--- a/scenarios/minimal/ansible.yml
+++ b/scenarios/minimal/ansible.yml
@@ -142,9 +142,6 @@ _core:
     - net_tools/basics/get_url.py
     - net_tools/basics/slurp.py
     - net_tools/basics/uri.py
-    - notification/irc.py
-    - notification/jabber.py
-    - notification/mail.py
     - packaging/language/pip.py
     - packaging/os/apt.py
     - packaging/os/apt_key.py

--- a/scenarios/minimal/misc.yml
+++ b/scenarios/minimal/misc.yml
@@ -2051,7 +2051,10 @@ glob:
     - notification/flowdock.py
     - notification/grove.py
     - notification/hipchat.py
+    - notification/irc.py
+    - notification/jabber.py
     - notification/logentries_msg.py
+    - notification/mail.py
     - notification/matrix.py
     - notification/mattermost.py
     - notification/mqtt.py


### PR DESCRIPTION
```gundalow 2:36 PM
@bcoca notification/irc notification/jabber notification/mail are in your minimal file
1) What use case is that for?
2) FYI they are currently all support:community
jctanner 2:42 PM
i suspect it was an oversight
gundalow 2:43 PM
Does Tower use them?
jctanner 2:44 PM
not sure tbh
https://docs.ansible.com/ansible-tower/latest/html/userguide/notifications.html#notification-types
iirc, they don't use ansible's code
pretty sure they rewrote those themselves
gundalow 2:45 PM
oh TIL
jctanner 2:45 PM
trying to confirm
bcoca 2:45 PM
msotly to uave aervice agnostic notification in core, also thought they were core
sorry sneeze while typing
but mostly i wantef a 'ding your hotpocket is ready'
```