### PR TITLE
[NWO] [WIP] Move junit callback plugin out of base

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -215,7 +215,6 @@ _core:
   callback:
   - debug.py
   - default.py
-  - junit.py
   - minimal.py
   - oneline.py
   - tree.py


### PR DESCRIPTION
The junit callback plugin is not useful for new end users so it doesn't
really fit the mandate of ansible-base.  However, it is needed for
ansible-test.  We need to consider how developers wanting to run
ansible-test will get the junit plugin to determine if we can remove
this or not.

/cc @mattclay